### PR TITLE
theme: update inline code css for pratcticalli theme to green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+
+## [2.0.2] - 2021-12-20
+
+### Changed
+* [#106](https://github.com/practicalli/blog/pull/106) CSS for inline code set to green in pratcialli theme
+
 ## [2.0.1] - 2021-12-13
 
 ### Added

--- a/themes/practicalli/css/screen.css
+++ b/themes/practicalli/css/screen.css
@@ -138,12 +138,14 @@ pre code {
     white-space: pre;
 }
 
+
 code {
-    color: #428bca;
+    color: #01833a;
 }
 
+
 pre, code, .hljs {
-    background-color: #f7f9fd;
+    background-color: #eeeeee85;
 }
 
 hr {


### PR DESCRIPTION
Blue color used for inline code was indistinguishable from the hyperlink color,
so inline code blocks changed to green

