### PR TITLE
theme: use graphic-design repository for post topic images

### DIFF
--- a/themes/practicalli/html/post-content.html
+++ b/themes/practicalli/html/post-content.html
@@ -9,7 +9,7 @@
 
     <!-- conditional topic logo displayed if :topic has value in a post -->
     {% if post.topic %}
-    <img class="topic" src="{{index-uri}}images/{{post.topic}}-logo-name.png" alt="{{post.topic}} logo" />
+    <img class="topic" src="https://raw.githubusercontent.com/practicalli/graphic-design/live/topic-images/{{post.topic}}-logo-name.png" alt="{{post.topic}} logo - post topic" />
     {% endif %}
 </div>
 <div>

--- a/themes/practicalli/html/previews.html
+++ b/themes/practicalli/html/previews.html
@@ -14,7 +14,7 @@
         </div>
         <!-- conditional topic logo displayed if :topic has value in a post -->
         {% if post.topic %}
-        <img class="topic" src="{{index-uri}}images/{{post.topic}}-logo-name.png" alt="{{post.topic}} logo" />
+        <img class="topic" src="https://raw.githubusercontent.com/practicalli/graphic-design/live/topic-images/{{post.topic}}-logo-name.png" alt="{{post.topic}} logo" />
         {% endif %}
     </div>
     {{post.content|safe}}


### PR DESCRIPTION
Update post-content and previews HTML code to pull images from the
practicalli/graphics-design repository

Saves the need to commit topic logo graphics to the blog repository and topic
images can be updated / added without having to rebuild the cryogen website

Resolve #118 