### PR TITLE
github actions: cache Clojure dependencies for staging blog build

### DIFF
--- a/.github/workflows/publish-blog-staging.yml
+++ b/.github/workflows/publish-blog-staging.yml
@@ -9,10 +9,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Prepare java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: 'Cache Clojure Dependencies'
         uses: actions/cache@v3

--- a/.github/workflows/publish-blog-staging.yml
+++ b/.github/workflows/publish-blog-staging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish to GitHub Pages
         # Publish to a separate repository as GitHub pages can only be served from one branch
         # Requires developer token as deploying across repositories
-        uses: JamesIves/github-pages-deploy-action@4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           repository-name: practicalli/blog-staging
           token: ${{ secrets.CRYOGEN_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-blog-staging.yml
+++ b/.github/workflows/publish-blog-staging.yml
@@ -24,9 +24,9 @@ jobs:
           restore-keys: cache-clojure-deps-
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.5
+        uses: DeLaGuardo/setup-clojure@9.5
         with:
-          cli: 1.10.3.943
+          cli: 1.11.1.1165
 
       - name: Build Blog site
         run: clojure -M:build content/config-staging.edn

--- a/.github/workflows/publish-blog-staging.yml
+++ b/.github/workflows/publish-blog-staging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish to GitHub Pages
         # Publish to a separate repository as GitHub pages can only be served from one branch
         # Requires developer token as deploying across repositories
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@4.4.0
         with:
           repository-name: practicalli/blog-staging
           token: ${{ secrets.CRYOGEN_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-blog-staging.yml
+++ b/.github/workflows/publish-blog-staging.yml
@@ -14,6 +14,15 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: 'Cache Clojure Dependencies'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: cache-clojure-deps-${{ hashFiles('**/deps.edn') }}
+          restore-keys: cache-clojure-deps-
+
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@3.5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [2.0.3] - 2022-10-02
+### Changed
+* Update setup-clojure, setup-java, github-pages-deploy GitHub actions to latest versions for staging blog publish
+
+
 ## [2.0.3] - 2022-01-28
 
 ### Added

--- a/content/md/posts/practicalli-plans-for-spring-2022.md
+++ b/content/md/posts/practicalli-plans-for-spring-2022.md
@@ -7,9 +7,9 @@
 
 Much more content is coming in the Spring of 2022, thanks to [Clojurists Together funding](https://www.clojuriststogether.org/news/q1-2022-funding-announcement/).  To ensure the most useful content is provides, Practicalli would value feedback on the planned topics.
 
-> Due to continued Covid symptoms, work is being done over 2022 and 2023 as health conditions allow
-
 The [submitted plan to Clojurists Together](https://www.clojuriststogether.org/news/q1-2022-funding-announcement/) is to extend existing guides and code examples, as well as adding new content to the existing Practicalli books.  Additional video content will be added across the Practicall Books, updating existing video content where it has become dated.
+
+> Due to continued Covid symptoms, work is being done over 2022 and 2023 as health conditions allow
 
 Videos will be created off-line rather than live broadcasts, to increase the quality of the videos.  Practicalli may do some live broadcasts again, however, these will be very experimental and unscripted (possibly subject to Covid brain fog too).
 


### PR DESCRIPTION
Use standard Cache GitHub Action to speed up build by caching the Clojure
dependencies for Cryogen