### PR TITLE
article: London Clojurains - a relatively brief history

### DIFF
--- a/content/md/posts/london-clojurians-community-a-brief-history.md
+++ b/content/md/posts/london-clojurians-community-a-brief-history.md
@@ -1,0 +1,241 @@
+{:title "London Clojurians Community - a relatively brief history"
+ :layout :post
+ :date "2023-03-10"
+ :topic "london-clojurians"
+ :tags  ["events" "community"]}
+
+The London Clojurian community started in 2009 when Robert Rees tricked Bruce Durling into organsing monthly events. From those humble beginnings the community has grown close to 4,000 members with several monthly events taking place fairly consistently over the last 14 years (5 events in 1 month was the record).
+
+The community has thrived due to the hard work of a great many people and this article probably misses out on a lot of activities (especially in the early years).  I would like to thank everyone involved in organising events, hosting events and attending events.  Without you there would not be a community.
+
+I steped down as one of the main organisers having delegated all of the work to many other people.  The last decade of community work has been very rewarding, but its time for other to continue the work.  I now focus on the [Practicalli websites](https://practical.li/) for learning and using Clojure effectively.
+
+<!-- more -->
+
+## In the beginning
+
+The London Clojurians community initially evolved from members and organisers in London Java Community.
+
+The London Java Community organised [a talk by Rich Hickey at SkillsMatter](https://skillsmatter.com/meetups/286-clojure-for-java-programmers) on 12th March 2009 (less than 2 years after the initial release of Clojure).
+
+The talk was entitled "Clojure for Java Developers", so naturally it attracted many people from the LJC and if I remember correctly it was a full house.
+
+Rich Hickey presented many topics that were included in the much longer talk: Clojure for Java Programmers [Part 1](https://www.youtube.com/watch?v=P76Vbsk_3J0) and [Part 2](https://www.youtube.com/watch?v=hb3rurFxrZ8)
+
+This inspired many Java developers to start looking at Clojure and was the foundation for creating the London Clojurains, which started with Clojure code dojo events.
+
+> SkillsMatter was London company that supported a wide range of software communities and hosted a great many Clojure talks and Clojure conferences.
+
+
+## Practice
+
+Inspired by the Rich Hickey talk, Bruce Durling organised the first ever London Clojurians event (allegedly tricked into it by Robert Rees who kindly persuaded Thoughworks his employer at the time to host the event).
+
+> The very first Clojure Dojo event announcement:
+>
+> On the 20th of July (2009) we have a Clojure Dojo. If you haven't heard of Clojure it is a LISP like language on the JVM that attempts to provide easy concurrency on multicore machines. It is surprisingly easy for Java developers to learn and provides powerful immutable data structures and concurrency models.
+>
+>The workshop aims to introduce you to the language and work on a problem as a group. Clojure is pretty new to most of us so beginners are welcome as well as people willing to help n00bs learn.
+
+
+Code dojos are a great place to practice and learn new aspects of Clojure language and its wide community of libraries.
+
+The premise of the dojo was to **raise everyones experience with Clojure** with a side goal of eating all the pizza generously provides by Thoughtworks (a few times we had sandwiches and queche instead, which was a nice change)
+
+The dojo events were initially quite daunting, with two people pairing (one with some experience with Clojure hopefully) whilst everyone else watched.  Then the pairs would switch.  The aim was to gradually evolve a single project, specifially a text-based adventure game called Clork (Zork in Clojure).
+
+> [Clork project](https://github.com/ldnclj/clork) is on the London Clojurian GitHub repository, although probably not considered state of the art of Clojure by now...
+
+The dojo format quickly evolved to be less intimidating. Collectively a list of ideas were gathered and voted on and then people split into groups of 3-4 people to solve the winning idea (or doing what ever they wanted in the group). People in each group took turns at the keyboard to write some code.  At the end of the event, each team presented the work they had done and lessons learned (there was no expectation to have something working, but there was lots of REPL based demos).
+
+> I initially went to the Clojure dojo events to learn how to run a dojo for the London Scala User Group.  After I while I realised that Clojure made far more sense to me that Scala ever did and Clojure was considerably more fun!  I eventually delegated the running of the Scala dojo to other people and invested my time learning Clojure instead.
+
+Code solutions were encouraged to be shared via the [London Clojurians GitHub organisation](https://github.com/ldnclj/) so the wider community could learn too.
+
+Yolina Sotirova hosted the Thoughworks dojo for many many years, laterly supported by Mario Giampietri and a few other willing Thoughtworkers.  Their offices are a few minutes walk from Picadilly Circus in the West End of London.
+
+Soon after the Thoughworks dojo started a second dojo begain at uSwitch, hosted by Christian Blunden, Aleksander Sumowski and many others.  uSwitch had been using Clojure for a while and it was great learning experience to experiment with them. Mark Mestern and many others help run the uSwitch monthly dojo to this day in their lovely offices just south of Tower Bridge.
+
+uSwitch and Thoughtworks have been long-term supporters of the code dojo events and after covid they are both running again
+
+> [Thoughtworks Clojure dojo](https://www.meetup.com/london-clojurians/events/zfckxsyfccbpc/) - Last Tuesday of the Month
+> [uSwitch Clojure dojo](https://www.meetup.com/london-clojurians/events/hlsswsyfcdbsb/) - Second Tuesday of the Month
+
+
+## Speaking events
+
+A monthly gathering where people shared their experiences or demonstrated work that they had done, including libraries and tools they created.
+
+This was an in-person event, so speakers and talks were quite London centric (the current online talks have a much broader scope) and the audience was limited.  However, SkillsMatter did record some of the events and they are available to view on their website.
+
+Some [London Clojurians speaking events](https://skillsmatter.com/groups/87-london-clojure-community#past_events) still have their videos available on the SkillsMatter website. Also try [search for videos on SkillsMatter site using the clojure tag](https://skillsmatter.com/explore?q=tag%3Aclojure).
+
+> [I presented several talks at SkillsMatter](https://gist.github.com/practicalli-john/ffa1a083cd1513cd7eded792fe6af030) over the years for a number of London communities. Many [SkillsCasts remain for now](https://skillsmatter.com/members/jr0cket#skillscasts) on the SkillsMatter website.
+
+
+## ClojureX Commercial Conference
+
+Together with SkillsMatter the London Clojurians ran 8 commercial conferences between 2011 and 2018 that attracted over 350 people at its peak.  Community members selected the talks and organised the schedule whilst SkillsMatter organised the venue, catering and sponsorship.
+
+I had the honour of hosting the last 3 conferences and creating the final schedule of talks to get a smooth flow throughout the two days.
+
+The conference had a wide audience and many of the people attending were quite new to Clojure, although as people returned each year there were more and more experienced Clojurians there for interesting chats outside the talks.
+
+In the years that I ran the conference it was a challenge to get enough speakers to cover a 2-day schedule.  To encourage new speakers I even ran [a public speaking workshop](https://www.youtube.com/watch?v=oRdpUCOmIaE&list=PLy9I_IfUBzKJBUDRJmZN-ypAYvsSc0TQ1&index=4).  In the end I managed to cagoule enough people to speak (flattery, usually well deserved, was a key to my success) even though some events like the panel talks I had to beg people to join.
+
+Although the conference came to an abrupt end due to SkillsMatter financial difficulties, it served a very valuable role in building up a community and extending the reach of Clojure to other developer communities.  A huge thanks to all the SkillsMatter staff that helped organise the conference
+
+* [ClojureX 2011](https://skillsmatter.com/conferences/1145-clojure-exchange#skillscasts) - MC Bruce Durling
+* [ClojureX 2012](https://skillsmatter.com/conferences/1235-clojure-exchange-2012#skillscasts) - MC Bruce Durling
+* [ClojureX 2013](https://skillsmatter.com/conferences/1579-clojure-exchange-2013#skillscasts) - MC Bruce Durling
+* [ClojureX 2014](https://skillsmatter.com/conferences/1956-clojure-exchange-2014#skillscasts) - MC Bruce Durling
+* [ClojureX 2015](https://skillsmatter.com/conferences/6861-clojure-exchange-2015#skillscasts) - MC Chris Howe Jones
+* [ClojureX 2016](https://skillsmatter.com/conferences/7430-clojure-exchange-2016#skillscasts) - MC John Stevenson
+* [ClojureX 2017](https://skillsmatter.com/conferences/8783-clojure-exchange-2017#skillscasts) - MC John Stevenson & Yolina Sotirova
+* [ClojureX 2018](https://skillsmatter.com/conferences/10459-clojure-exchange-2018#skillscasts) - MC John Stevenson
+
+
+## EuroClojure
+
+On May 24 & 25 of 2012 London hosted the EuroClojure conference, the first Clojure conference organised by Cognitect outside of the USA.  There were several EuroClojure events that were followed by communities across Europe creating their own events ([Dutch Clojure Days](https://clojuredays.org/), [[ClojureD](https://clojured.de/), [Heart of Clojure](https://heartofclojure.eu/l))
+
+Many people from the London Clojurians community spoke and there was an excellent range of talks. From the awe inspring musical creations of overtone, engaging talks on CQRS, Cascalog and lossy Data Warehouses, to the inspiring talks from Rich Hickey (who gave two talks in the end).
+
+250 attendees eagerly listening to 35 talks over the two days and there were many exciting hallway conversations inbetween talks.
+
+[EuroClojure London presentation videos](https://vimeo.com/euroclojure)
+
+[Day One](https://otfrom.wordpress.com/2012/05/27/euroclojure-2012-overview-and-day-one/) and [Day Two](https://otfrom.wordpress.com/2012/05/28/euroclojure-2012-part-2/) conference write-ups from Bruce Durling
+
+> [IN/Clojure](https://inclojure.org/) is another community driven conference based in India
+
+
+## Increasing Reach
+
+Whist presenting on Clojure at many other London developer communities I was always asked if there was a Clojure community people could join.  There was a healthy community, but it wasnt very visible.  Events were organised via Eventbrite and posted on the London Clojurians Google mailing list so were hard to find unless already part of the community.
+
+After discussing with the other organisers, I created a [Meetup.com site for London Clojurians](https://www.meetup.com/london-clojurians/) and with in a day we had over 100 members and within a year it was over 1,000 members.  It was much easier for people to find and join in with our events after that.
+
+I created a [logo design for the community](https://github.com/practicalli-john/london-clojurians-logo) to help people recognise our work and gave out free stickers at our events and conferences and any others I spoke at.  This helped raise awarness of the community and increased membership on the meetup site.
+
+A Website was also developed using ClojureScript and used as one of the learning paths for the London ClojureBridge events.
+
+I also had the chance to give Clojure talks and workshops across Europe (Germany, The Netherlands, Italy) and the USA (San Francisco), helping spread interest far and wide.
+
+Although the majority of my talks were not recorded, some of my most notable speaking experience include:
+
+* [Clojure Made Simple at JAX London, 23 October 2012](https://www.slideshare.net/jaxlondon2012/clojure-madesimple-john-stevenson) - My very first talk on Clojure and I learned a lot (although I don't know if the audience did)
+* [Get into Functional Programming with Clojure at CeBit](https://www.youtube.com/watch?v=mEfqULqChZs&list=PLy9I_IfUBzKJBUDRJmZN-ypAYvsSc0TQ1&index=10) - March 2016 in Hanover, Germany.  My first Clojure talk at Europe's biggest technology exhibition (recorded on a GoPro, so the video is a little curvy)
+* [Guiding People into Clojure](https://www.youtube.com/watch?v=XPLZq-5Y_rA&list=PLy9I_IfUBzKJBUDRJmZN-ypAYvsSc0TQ1&index=3) - Clojure Remote 2016 - my first virtual conference and first virtual presentation (I was very nervous).
+* [Fun with Functional Programing in Clojure at Codemotion Amsterdam](https://www.youtube.com/watch?v=ztv1bfH2Vv0), 11th May 2016 - possibly the first Clojure talk I enjoyed all the way through
+* [lojureScript - Making Front-End development Fun again](https://www.youtube.com/watch?v=sPK_wLI_D-o&list=PLy9I_IfUBzKJBUDRJmZN-ypAYvsSc0TQ1&index=12) at Codemotion Amsterdam - was doing okay until I discovered [Russ Olsen from Cognitect](https://cognitect.com/authors/RussOlsen.html) in the audience (I was sure I was going to say all the wrong things after that).  I had a great talk with Russ after the conference.
+* [Get into Functional Programming on the JVM with Clojure](https://www.youtube.com/watch?v=Y2DWvGLGPdY&list=PLy9I_IfUBzKJBUDRJmZN-ypAYvsSc0TQ1&index=8) - my first and only visit to [Sofia, Bulgaria](https://www.sofia.bg/) in 2018.  The home of Bohzidar the creator of Emacs CIDER.
+
+
+## Hack the tower workshops
+
+After a successful Hack day at the Guardian offices and an enlightening [Clojure Hackday at thoughtworks](https://jr0cket.co.uk/2012/02/developers-making-music-together-london.html.html), I decided to create a regular Hack day called [Hack The Tower](https://hacktogetherldn.github.io/).  The event was scheduled in the Clojure, Java and Scala communities (as I had been helping to organise events for them) and open to anyone else that wanted to come really.
+
+I was working at Heroku/Salesforce offices in Tower 42 (hence Hack The Tower name for the event) and realised no one used their offices on the weekend, so got permission to run a Saturday even ever month (ensuring the building security staff were happy).
+
+I was quite surprised when 20+ people turned up on a chilly November day (28th to co-inside with International day-of-code).  Much fun and knowledge sharing was happening as we worked together on ideas in small groups.  We even had some [robots to control with code](https://youtu.be/rJnjmwtGQuE). Not even the faint smell of stale coffee left by the sales teams the day before stopped people enjoying themselves.
+
+The event had a reboot when Salesforce moved into floor 26, 27 & 28 of the Heron Tower (Salesforce Tower).  This was a beautiful and large office space which easily held over 100 people for a hack day.
+
+> [Hack The Tower writeup - February 2013](https://jr0cket.co.uk/2013/02/hack-tower-february-2013.html) - jr0cket blog
+
+Hack The Tower ran every month for 5 years whilst I was at Salesforce and food was sponsored by Salesforce (and carried in several super-size bags from Tescos by myself each time - so a bit of exercise for me)
+
+> Another  bit of exercise to chase down everyone at the end of the day across all the many rooms, ensuring I was the last too leave :)
+
+![View from Hack The Tower event - London Salesforce offices](https://raw.githubusercontent.com/practicalli/graphic-design/live/events/hack-the-tower-view-rainbow.png)
+
+
+## ClojureBridge London
+
+uSwitch ran the first ClojureBridge London event in February 2014 with about 8 organisers who had no experience in how to run such an event (or what it should look like).  Thanks to Anna Pawlicka we manage to get organised and ran a very successful event for 38 people, with about 10 volunteers on the day.
+
+There has always been a very mixed audience at each event, from those who have never written code before to those with some professional experience (but no Clojure experience).  Attendees were put into groups of 3-5 people with one or more voluneers as their guide through Clojure.
+
+Initially the clojurebridge.org content was used, although after the first event we started to extend and enhance the learning materials.  I did a lot of work to create [specific learning paths and engaging exercises](https://clojurebridgelondon.github.io/#learning-paths) for students at different levels of experience.  Work that motivated me to create the Practicalli series of on line books.
+
+GeekGirls Scotland ran a ClojureBridge event on September 27th 2014 at CodeBase in Edinburgh.
+
+I wasn involved in organising all 13 events over the last 8 years...  https://clojurebridgelondon.github.io/organise-clojurebridge-london/
+
+[ClojureBridge London website](https://clojurebridgelondon.github.io/)
+
+
+## reClojure community conference
+
+Early November 2019 I was very busy organising the ClojureX conference and getting the last few speakers for the 2 day conference with SkillsMatter.  Then I got a message saying SkillsMatter had declared banckrupcy and all conferences were cancelled.  Within a day SkillsMatter had shut down and all the staff let go.
+
+This did leave some of our speakers having to cancel travel plans (one speaker even coming from Austraila) and hopefully reclaim their expenditure.
+
+I had though it impossible to organise a replacement conference (especially on my own).  However, Renzo Borgatti, Bruno Bonacci and several other people stepped up and made reClojure community conference happen, all within the space of about 6 weeks.
+
+reClojure in 2019 was an in-person event held at the Crypt, a venue we used to use for the ClojureX conference back in the early days.  Cognitect supplied a big chunk of the money for the venue and many other companies working with Clojure also contributed.  Over 100 people attended the free conference and it was a roaring success.
+
+> I had been talking about running a community conference for the last year or so, but there was so much already going on it was hard to schedule.  Although there was short term problems for some of the speakers and attendees, I am please (releaved) that a community conference was established.
+
+Due to the coronavirus pandemice (which I am still afected by unfortunately) the 2020 reClojure event was online, with attendees joining via Zoom and able to ask questions in speaker panels.  The conference was also live streamed on YouTube as more people wanted to join in that we had Zoom places for.  The online conference has continued to increase in popularity, so much so that we keep increasing the Zoom plan required to include everyone that wants to attend.
+
+Although the thought of another in-person conference has been discussed many times, the reach the online conference gives far outways any benefits (and an online conference, although a lot of work, is still less work than an in-person event).
+
+
+## Monthly talks Online
+
+September 2018 I left my role at Citi (a financial company where I ran 5 teams across several continents).  I decided to focus on filling in all the gaps in my Clojure knowlege, so did the [100 days of code challenge](https://github.com/practicalli-john/100-days-of-clojure-code).  Half-way through the challenge I started the Practicalli YouTube channel and ran a weekly Clojure study event online, which proved very popular and a viable way to do live coding and presentations.
+
+Over the next 2 years I created 100+ hours of video content showing my Clojure coding skills (or occasionally lack of them).
+
+Due to the Covid pandemic and lack of venue (after SkillsMatter closed their offices) there was little opportunity to do in-person talks and it had become very difficult to get people to present (only a few talks a year happened during 2018 & 2019).
+
+Taking the talks online had been suggested many times over the years to increase the pool of speakers. Bruno Bonacci took the initiative and started organising the virtual presentations and they really took off, so much more than we could do with in-person events.  Bruno has done an amazing job of organising a huge list of diverse topics and speakers.  Thank you Bruno.
+
+The talks are so popular they are becoming more regular, from monthly to bi-weekly.
+
+All the videos are uploaded to the [London Clojurains YouTube Channel](https://www.youtube.com/london-clojurians) that I set up and delegated ownership to Renzo Borgatti.  The latest reColojure videos can also be found on this channel.
+
+[![London Clojurians YouTube banner](https://raw.githubusercontent.com/practicalli/graphic-design/live/banners/london-clojurians-banner-youtube.png)](https://www.youtube.com/london-clojurians)
+
+
+## Financial Support
+
+Many companies and individuals ask if they could sponsor the community over the years, but most of the community ran with no actual costs as all the work was done on a volunteer basis.
+
+Thoughworks and uSwitch hosting (and providing refreshments) for the dojos and SkillsMatter hosted the talks and conferences (which many companies did sponsor, although that was directly to SkillsMatter).
+
+When London Clojurians started reClojure conference though, there was a need for financial help.  The conference was free to attend, so the venue, catering and filming created costs.
+
+I suggested to Renzo Borgatti and Bruno Bonacci that we start the [London Clojurains Open Collective](https://opencollective.com/london-clojurians) as a completely transparent way for anyone to financially support the community.  Either for specific events like reClojure or in general to help the community to do much more.
+
+The financial support has taken the burdon of volunteers to pay for essential tools such as Meetup.com and Zoom video conference, which had previously been paid by those managing those services.
+
+The community uses freely available services where possible, e.g GitHub for code sharing and GitHub pages to host websites and learning materials.
+
+
+## Resources
+
+* [London Clojurains Meetup site](https://www.meetup.com/London-Clojurians/)
+* [London Clojurains Landing Page](https://londonclojurians.org/) - written in ClojureScript
+* [London Clojurains YouTube Channel](https://www.youtube.com/london-clojurians)
+* [Practicalli YouTube Channel](https://www.youtube.com/practicalli)
+* [London Clojurains Open Collective](https://opencollective.com/london-clojurians)
+* [London Clojurains - reClojure online conference](https://www.reclojure.org/)
+* [London Clojurains GitHub Organisation](https://github.com/ldnclj) - code from dojo and other events
+
+
+## Summary
+
+It has been a pleasure and an honour to help build the London Clojurians community to nearly 4,000 members and be involved with hundereds of events over the last 13 years.
+
+My favourite events were the coding dojos which helped me solve many of the [4Ever Clojure challenges](https://practical.li/clojure/coding-challenges/4clojure/) and appreciate the joy of Clojure.  I attended almost every dojo between 2014 and 2019 and learned a great deal from helping others learn Clojure too.
+
+I have fond memories of the 5 years of workshops I ran as part of Hack The Tower. Often they were quite nerve-racking as it was often the case of only knowing slightly more than they people I was helping.  Or more often knowing what words to put into an internet search and applying the examples found without people wondering how little I really knew.
+
+Learning by helping people has been a big motivating part of my community activities and this will continue as part of the Practicalli books and videos.  This is where I will focus my efforts from now on, although I am happy to advise anyone is running (or interested in running) community events.
+
+Thank you
+
+John Stevenson | [practical.li](https://practical.li/)


### PR DESCRIPTION
## Description
A relatively brief history of the London Clojurians, mostly covering aspects that I was involved in (as that is what I recall).  Some digging in the Google mailing list and on meetup was required to figure out some of the info on the early days of the community

> Draft - work in progress and hopefully get feedback before the final article published

