### PR TITLE
article: what java knowledge required for clojure development

### DIFF
--- a/content/md/posts/build-and-run-clojure-with-multistage-dockerfile.md
+++ b/content/md/posts/build-and-run-clojure-with-multistage-dockerfile.md
@@ -89,7 +89,7 @@ Now the dependencies are downloaded (and cached), copy the project files to the 
 
 ```dockerfile
 COPY ./ /build
-RUN clojure -X:package/uberjar
+RUN clojure -T:build
 ```
 
 > See the section on Docker Ignore Patters to make the COPY command more efficient


### PR DESCRIPTION
Although Java and JVM knowledge is not essential for Clojure development, there are some basic concepts that can come in useful.